### PR TITLE
Link: Adding base prototype without theming

### DIFF
--- a/change/@fluentui-base-2019-10-30-15-15-49-linkPrototype.json
+++ b/change/@fluentui-base-2019-10-30-15-15-49-linkPrototype.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Link: Adding base prototype without theming.",
+  "packageName": "@fluentui/base",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "a79c62f9f9cbfd238b5a96aec40dc673d9e9ee92",
+  "date": "2019-10-30T22:15:49.580Z",
+  "file": "D:\\fluent-ui\\change\\@fluentui-base-2019-10-30-15-15-49-linkPrototype.json"
+}

--- a/packages/base/src/components/Link/Link.base.tsx
+++ b/packages/base/src/components/Link/Link.base.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import PropTypes from "prop-types";
+import { ILinkProps, ILinkSlots } from "./Link.types";
+import { useLink } from "./useLink";
+
+export const LinkBase: React.FunctionComponent<ILinkProps> = (
+  props: ILinkProps
+) => {
+  const { children, href, slots } = props;
+    const tag = _deriveRootType(href);
+    const {
+        root: Root = tag
+    } = (slots || {}) as ILinkSlots;
+
+    const { slotProps = {} } = useLink(props);
+
+    return (
+        <Root {...slotProps.root}>
+            {children}
+        </Root>
+    );
+};
+
+
+function _deriveRootType(href?: string): 'a' | 'button' {
+    return href ? 'a' : 'button';
+}
+
+/**
+ * Button component proptypes.
+ */
+LinkBase.propTypes = {
+    children: PropTypes.node,
+    disabled: PropTypes.bool,
+    href: PropTypes.string,
+
+    /** slots */
+    slots: PropTypes.shape({
+        root: PropTypes.elementType.isRequired
+    }),
+
+    /** slot props */
+    slotProps: PropTypes.shape({
+        root: PropTypes.object
+    })
+}; 

--- a/packages/base/src/components/Link/Link.base.tsx
+++ b/packages/base/src/components/Link/Link.base.tsx
@@ -7,9 +7,8 @@ export const LinkBase: React.FunctionComponent<ILinkProps> = (
   props: ILinkProps
 ) => {
   const { children, href, slots } = props;
-    const tag = _deriveRootType(href);
     const {
-        root: Root = tag
+        root: Root = href ? 'a' : 'button'
     } = (slots || {}) as ILinkSlots;
 
     const { slotProps = {} } = useLink(props);
@@ -20,27 +19,3 @@ export const LinkBase: React.FunctionComponent<ILinkProps> = (
         </Root>
     );
 };
-
-
-function _deriveRootType(href?: string): 'a' | 'button' {
-    return href ? 'a' : 'button';
-}
-
-/**
- * Button component proptypes.
- */
-LinkBase.propTypes = {
-    children: PropTypes.node,
-    disabled: PropTypes.bool,
-    href: PropTypes.string,
-
-    /** slots */
-    slots: PropTypes.shape({
-        root: PropTypes.elementType.isRequired
-    }),
-
-    /** slot props */
-    slotProps: PropTypes.shape({
-        root: PropTypes.object
-    })
-}; 

--- a/packages/base/src/components/Link/Link.stories.tsx
+++ b/packages/base/src/components/Link/Link.stories.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { LinkBase } from "./Link.base";
+
+export default {
+  component: "Link",
+  title: "Base Link"
+};
+
+export const baseLink = () => (
+  <LinkBase href="https://www.bing.com">
+    This renders as a link
+  </LinkBase>
+);
+
+export const baseLinkWithoutHref = () => (
+  <LinkBase>
+    This renders as a button
+  </LinkBase>
+); 

--- a/packages/base/src/components/Link/Link.types.ts
+++ b/packages/base/src/components/Link/Link.types.ts
@@ -1,0 +1,21 @@
+import { IClasses, ISlotProps, ISlottableProps } from "../../utilities/ISlots";
+
+export interface ILinkSlots {
+  /** Intended to contain the link. */
+  root: React.ReactType;
+}
+
+export type ILinkSlotProps = ISlotProps<ILinkSlots>;
+
+export interface ILinkClasses extends IClasses<ILinkSlots> {}
+
+export interface ILinkProps extends ISlottableProps<ILinkSlotProps, ILinkClasses> {
+  /** Defines the children of the Link component. */
+  children?: React.ReactNode;
+
+  /** Defines whether the Link is in an enabled or disabled state. */
+  disabled?: boolean;
+
+  /** Defines an href that serves as the navigation destination when clicking on the Link. */
+  href?: string;
+}

--- a/packages/base/src/components/Link/useLink.ts
+++ b/packages/base/src/components/Link/useLink.ts
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { mergeSlotProps } from "@fluentui/react-theming";
+import { ILinkProps } from "./Link.types";
+
+export interface ILinkState {
+  rootRef: React.Ref<Element>;
+}
+
+const useLinkState = (userProps: ILinkProps): ILinkState => {
+  const rootRef = React.useRef<HTMLElement>(null);
+
+  return { 
+    rootRef
+  };
+};
+
+export const useLink = (props: ILinkProps) => {
+  const { disabled, href } = props;
+
+  const state = useLinkState(props);
+  const { rootRef } = state;
+
+  const slotProps = mergeSlotProps(props, {
+    root: {
+      "aria-disabled": disabled,
+      href,
+      ref: rootRef,
+      role: "link",
+      type: href ? "link" : "button"
+    }
+  })
+
+  return {
+    slotProps,
+    state
+  };
+};


### PR DESCRIPTION
This PR adds a base prototype for the `Link` component.

_Disclaimer:_ Everything is up for discussion at this point and I'm mainly putting this forward to get feedback and iterate.