### PR TITLE
Enables class examples inside the stardust-ui/react-docs

### DIFF
--- a/change/@stardust-ui-react-docs-2019-10-30-10-39-06-class-example.json
+++ b/change/@stardust-ui-react-docs-2019-10-30-10-39-06-class-example.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "added config bits to handle examples that are class based",
+  "packageName": "@stardust-ui/react-docs",
+  "email": "kchau@microsoft.com",
+  "commit": "88f5ffb9ada8f00fb528ace37e6597089a0dab7e",
+  "date": "2019-10-30T17:39:06.862Z",
+  "file": "/Users/ken/workspace/fluent/change/@stardust-ui-react-docs-2019-10-30-10-39-06-class-example.json"
+}

--- a/packages/stardust-ui/react-docs/.storybook/config.js
+++ b/packages/stardust-ui/react-docs/.storybook/config.js
@@ -37,6 +37,10 @@ export const req = require.context(
   /(\w+Example(\w|\.)*|\w+.perf)\.tsx$/,
 )
 
+function isFunctionalComponent(Component) {
+  return !Component.prototype.render
+}
+
 function loadStories() {
   const stories = new Map()
   const nameMatcher = /\.\/([^/]+)\//
@@ -56,7 +60,16 @@ function loadStories() {
 
       const storyName = key.substr(key.lastIndexOf('/') + 1).replace('.tsx', '')
       const story = stories.get(componentName)
-      story[storyName] = req(key).default
+
+      const Component = req(key).default
+
+      if (Component) {
+        if (isFunctionalComponent(Component)) {
+          story[storyName] = Component
+        } else {
+          story[storyName] = () => <Component />
+        }
+      }
     }
   })
 


### PR DESCRIPTION
Some of the examples exports a class component rather than the CSF exporting function component representing a story. This addresses the issue by detecting whether the export is classical and would shim a functional component on top of it.